### PR TITLE
Added resize listener to message component

### DIFF
--- a/src/js/views/monitor/messageComponent.jsx
+++ b/src/js/views/monitor/messageComponent.jsx
@@ -13,11 +13,12 @@ module.exports = React.createClass({
     )
   },
 
-  shouldComponentUpdate: function () {
-    return false
+  componentDidMount: function () {
+    var $node = $(React.findDOMNode(this))
+    styler.styleProjects([{name: this.props.message}], $node, $node.parent())
   },
 
-  componentDidMount: function () {
+  componentDidUpdate: function () {
     var $node = $(React.findDOMNode(this))
     styler.styleProjects([{name: this.props.message}], $node, $node.parent())
   }

--- a/src/js/views/monitor/monitorSection.jsx
+++ b/src/js/views/monitor/monitorSection.jsx
@@ -43,6 +43,7 @@ module.exports = React.createClass({
   },
 
   componentDidMount: function () {
+    window.addEventListener('resize', this._onChange)
     InterestingProjectsStore.addListener(this._onChange)
     InterestingProjectActions.pollForChanges(5000, TrayStore.getAll, SelectedProjectsStore.getAll)
 
@@ -50,6 +51,7 @@ module.exports = React.createClass({
   },
 
   componentWillUnmount: function () {
+    window.removeEventListener('resize', this._onChange)
     InterestingProjectsStore.removeListener(this._onChange)
     InterestingProjectActions.stopPollingForChanges()
 


### PR DESCRIPTION
![All the responsiveness](https://cloud.githubusercontent.com/assets/653864/11616047/bb16e4bc-9c68-11e5-9ed6-34da890b9a1a.gif)

Resolves #91.

I've made an attempt at fixing the problem with the success message not resizing with the window. It's looking like it works.

I'm a complete beginner to React, so if you were expecting a different way of doing it, please let me know. :smile: