### PR TITLE
Transforming JSON key format for requests and responses

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
                            [ring/ring-json "0.4.0"]
                            [ring/ring-defaults "0.1.5"]
                            [bk/ring-gzip "0.1.1"]
-                           [base64-clj "0.1.1"]]
+                           [base64-clj "0.1.1"]
+                           [camel-snake-kebab "0.3.2"]]
             :plugins [[lein-ring "0.9.7"]
                       [environ/environ.lein "0.3.1"]]
             :min-lein-version "2.0.0"

--- a/src/js/stores/FetchedProjectsStore.js
+++ b/src/js/stores/FetchedProjectsStore.js
@@ -14,7 +14,7 @@ function previouslyRemovedProjects(project) {
 
 function updateNewAndRemovedFlags(fetchedProjects, project) {
   var whereIdsMatch = function (fetchedProject) {
-    return fetchedProject['project-id'] === project.projectId
+    return fetchedProject.projectId === project.projectId
   }
   return {
     projectId: project.projectId,
@@ -30,7 +30,7 @@ function getName(project) {
 
 function toProject(project) {
   return {
-    projectId: project['project-id'],
+    projectId: project.projectId,
     name: getName(project),
     isNew: true,
     wasRemoved: false

--- a/src/js/stores/InterestingProjectsStore.js
+++ b/src/js/stores/InterestingProjectsStore.js
@@ -16,7 +16,7 @@ function getName(apiProject) {
 
 function toProject(apiProject) {
   return {
-    projectId: apiProject['project-id'],
+    projectId: apiProject.projectId,
     name: getName(apiProject),
     prognosis: apiProject.prognosis
   }

--- a/src/nevergreen/api/projects.clj
+++ b/src/nevergreen/api/projects.clj
@@ -53,7 +53,7 @@
   (->> (get-all tray)
        (filtering/interesting)
        (filter-by-ids (:included tray))
-       (add-tray-id (:trayId tray))))
+       (add-tray-id (:tray-id tray))))
 
 (defn get-interesting [trays]
   (if (= (count trays) 1)

--- a/src/nevergreen/api/routes.clj
+++ b/src/nevergreen/api/routes.clj
@@ -4,6 +4,7 @@
             [nevergreen.api.security :as security]
             [ring.middleware.json :refer [wrap-json-body wrap-json-response]]
             [nevergreen.wrap-cache-control :refer [wrap-cache-control]]
+            [nevergreen.wrap-convert-keys :refer [wrap-convert-keys]]
             [nevergreen.wrap-cors-headers :refer [wrap-cors-headers]]
             [nevergreen.wrap-exceptions :refer [wrap-exceptions]]
             [nevergreen.wrap-redact-sensitive :refer [wrap-redact-sensitive wrap-restore-sensitive]]
@@ -31,6 +32,7 @@
 
 (defn wrap-api-middleware [routes]
   (-> routes
+      wrap-convert-keys
       wrap-logging
       (wrap-json-body {:keywords? true})
       (wrap-json-response {:pretty true})

--- a/src/nevergreen/wrap_convert_keys.clj
+++ b/src/nevergreen/wrap_convert_keys.clj
@@ -1,0 +1,8 @@
+(ns nevergreen.wrap-convert-keys
+  (require [camel-snake-kebab.core :refer [->camelCase]]
+           [camel-snake-kebab.extras :refer [transform-keys]]))
+
+(defn wrap-convert-keys [app]
+  (fn [req]
+    (let [res (app req)]
+      (transform-keys ->camelCase res))))

--- a/src/nevergreen/wrap_convert_keys.clj
+++ b/src/nevergreen/wrap_convert_keys.clj
@@ -1,8 +1,9 @@
 (ns nevergreen.wrap-convert-keys
-  (require [camel-snake-kebab.core :refer [->camelCase]]
+  (require [camel-snake-kebab.core :refer [->camelCase ->kebab-case]]
            [camel-snake-kebab.extras :refer [transform-keys]]))
 
-(defn wrap-convert-keys [app]
+(defn wrap-convert-keys [handler]
   (fn [req]
-    (let [res (app req)]
+    (let [transformed-req (update-in req [:body] (partial transform-keys ->kebab-case))
+          res (handler transformed-req)]
       (transform-keys ->camelCase res))))

--- a/test/js/stores/FetchedProjectsStoreTest.js
+++ b/test/js/stores/FetchedProjectsStoreTest.js
@@ -49,12 +49,12 @@ describe('fetched projects store', function () {
         type: Constants.ProjectsFetched,
         trayId: 'some-id',
         projects: [{
-          'project-id': 'some-project-id',
+          projectId: 'some-project-id',
           name: 'name',
           stage: 'stage',
           job: null
         }, {
-          'project-id': 'another-project-id',
+          projectId: 'another-project-id',
           name: 'something-else',
           stage: 'stage',
           job: 'job'
@@ -74,7 +74,7 @@ describe('fetched projects store', function () {
           type: Constants.ProjectsFetched,
           trayId: 'some-id',
           projects: [{
-            'project-id': 'some-project-id',
+            projectId: 'some-project-id',
             name: 'name',
             stage: 'stage',
             job: null
@@ -87,7 +87,7 @@ describe('fetched projects store', function () {
           type: Constants.ProjectsFetched,
           trayId: 'some-id',
           projects: [{
-            'project-id': 'some-project-id',
+            projectId: 'some-project-id',
             name: 'name',
             stage: 'stage',
             job: null

--- a/test/js/stores/InterestingProjectsStoreTest.js
+++ b/test/js/stores/InterestingProjectsStoreTest.js
@@ -28,7 +28,7 @@ describe('success store', function () {
     callback({
       type: Constants.InterestingProjects,
       projects: [{
-        'project-id': 'some-id',
+        projectId: 'some-id',
         name: 'name',
         stage: 'stage',
         prognosis: 'some-prognosis'

--- a/test/nevergreen/api/projects_test.clj
+++ b/test/nevergreen/api/projects_test.clj
@@ -15,7 +15,7 @@
              (subject/get-interesting [{:url "not-http"}]) => (throws Exception))
 
        (fact "removes healthy projects"
-             (subject/get-interesting [{:trayId "a-tray" :included ["project-1"] :url valid-url}]) => (list)
+             (subject/get-interesting [{:tray-id "a-tray" :included ["project-1"] :url valid-url}]) => (list)
              (provided
                (subject/get-all anything) => [{:project-id "project-1" :prognosis :healthy}]))
 

--- a/test/nevergreen/wrap_convert_keys_test.clj
+++ b/test/nevergreen/wrap_convert_keys_test.clj
@@ -1,0 +1,9 @@
+(ns nevergreen.wrap-convert-keys-test
+  (:require [midje.sweet :refer :all]
+            [nevergreen.wrap-convert-keys :as subject]))
+
+(facts "wrap convert keys"
+       (fact "converts responses from kebab-case to camelCase"
+             ((subject/wrap-convert-keys ..app..) ..req..) => {:someKey "some-value"}
+       (provided
+         (..app.. ..req..) => {:some-key "some-value"})))

--- a/test/nevergreen/wrap_convert_keys_test.clj
+++ b/test/nevergreen/wrap_convert_keys_test.clj
@@ -3,7 +3,12 @@
             [nevergreen.wrap-convert-keys :as subject]))
 
 (facts "wrap convert keys"
+       (fact "converts requests from kebab-case to camelCase"
+             ((subject/wrap-convert-keys ..handler..) {:body {:someKey "some-value"}}) => irrelevant
+             (provided
+               (..handler.. {:body {:some-key "some-value"}}) => irrelevant))
+
        (fact "converts responses from kebab-case to camelCase"
-             ((subject/wrap-convert-keys ..app..) ..req..) => {:someKey "some-value"}
-       (provided
-         (..app.. ..req..) => {:some-key "some-value"})))
+             ((subject/wrap-convert-keys ..handler..) {:body {:some-key "some-value"}}) => {:anotherKey "another-value"}
+             (provided
+               (..handler.. {:body {:some-key "some-value"}}) => {:another-key "another-value"})))


### PR DESCRIPTION
Resolves #98.

This makes the API return lower camel case on all responses, and transforms incoming request bodies into kebab-case. It also includes changes on the JS end for dealing with that new API. For example:

```json
Request URL:http://localhost:5000/api/projects/interesting
Request Method:POST
Status Code:200 OK

[ {
  "lastBuildTime" : "2015-12-08T08:05:32.000Z",
  "nextBuildTime" : null,
  "stage" : null,
  "name" : "lucene solr nightly tests 5.4",
  "lastBuildStatus" : "failure",
  "activity" : "sleeping",
  "messages" : [ ],
  "lastBuildLabel" : "12",
  "webUrl" : "https://builds.apache.org/job/Lucene-Solr-NightlyTests-5.4/",
  "projectId" : "bHVjZW5lIHNvbHIgbmlnaHRseSB0ZXN0cyA1LjQvLw==",
  "trayId" : "e1c5102f-1340-453a-85d7-53ab5cf17d2d",
  "prognosis" : "sick",
  "owner" : null,
  "job" : null
}]
```

Feedback welcome, I'm not familiar much with Clojure so any feedback is appreciated. Also, this will break the API, so that might be worth mentioning to users if this is merged.