### PR TITLE
Changing /api/projects/all to take a list of trays

### DIFF
--- a/src/js/actions/TrayActions.js
+++ b/src/js/actions/TrayActions.js
@@ -55,7 +55,7 @@ module.exports = {
 
   refreshTray: function (tray) {
     this._dispatchProjectsFetching(tray.trayId)
-    return projectsGateway.fetchAll(tray).then(function (projects) {
+    return projectsGateway.fetchAll([tray]).then(function (projects) {
       this._dispatchProjectsLoaded(tray.trayId, projects)
     }.bind(this)).catch(function (err) {
       this._dispatchApiError(tray.trayId, err)

--- a/src/js/gateways/projectsGateway.js
+++ b/src/js/gateways/projectsGateway.js
@@ -1,13 +1,15 @@
 var gateway = require('../gateways/gateway')
 
 module.exports = {
-  fetchAll: function (tray) {
-    var data = {
-      url: tray.url,
-      username: tray.username,
-      password: tray.password,
-      serverType: tray.serverType
-    }
+  fetchAll: function (trays) {
+    var data = trays.map(function (tray) {
+      return {
+        url: tray.url,
+        username: tray.username,
+        password: tray.password,
+        serverType: tray.serverType
+      }
+    })
 
     return gateway.post('/api/projects/all', data)
   },

--- a/src/nevergreen/api/projects.clj
+++ b/src/nevergreen/api/projects.clj
@@ -39,7 +39,7 @@
 (defn- add-tray-id [tray-id projects]
   (map #(merge {:tray-id tray-id} %) projects))
 
-(defn get-all [tray]
+(defn fetch-tray [tray]
   (ensure-url-is-valid tray)
   (let [server-type (get-server-type tray)
         decrypted-password (if-not (blank? (:password tray)) (crypt/decrypt (:password tray)))]
@@ -49,8 +49,13 @@
         {:normalise true :server server-type})
       (add-project-ids))))
 
+(defn get-all [trays]
+  (if (= (count trays) 1)
+    (fetch-tray (first trays))
+    (flatten (pmap fetch-tray trays))))
+
 (defn fetch-interesting [tray]
-  (->> (get-all tray)
+  (->> (fetch-tray tray)
        (filtering/interesting)
        (filter-by-ids (:included tray))
        (add-tray-id (:trayId tray))))

--- a/test/js/gateways/projectsGatewayTest.js
+++ b/test/js/gateways/projectsGatewayTest.js
@@ -11,16 +11,21 @@ describe('projects gateway', function () {
 
   describe('getting all projects', function () {
     it('has all data', function () {
-      var tray = {
+      var trays = [{
         url: 'url',
         username: 'uname',
         password: 'pword',
         serverType: 'GO'
-      }
+      }, {
+        url: 'another-url',
+        username: 'another-uname',
+        password: 'another-pword',
+        serverType: 'GO'
+      }]
 
-      subject.fetchAll(tray)
+      subject.fetchAll(trays)
 
-      expect(gateway.post).toBeCalledWith('/api/projects/all', tray)
+      expect(gateway.post).toBeCalledWith('/api/projects/all', trays)
     })
   })
 
@@ -46,6 +51,7 @@ describe('projects gateway', function () {
         included: ['some-project-id'],
         serverType: tray.serverType
       }]
+
       expect(gateway.post).toBeCalledWith('/api/projects/interesting', data)
     })
   })

--- a/test/js/gateways/projectsGatewayTest.js
+++ b/test/js/gateways/projectsGatewayTest.js
@@ -1,12 +1,27 @@
 jest.dontMock('../../../src/js/gateways/projectsGateway')
 
-describe('repository', function () {
+describe('projects gateway', function () {
 
   var subject, gateway
 
   beforeEach(function () {
     subject = require('../../../src/js/gateways/projectsGateway')
     gateway = require('../../../src/js/gateways/gateway')
+  })
+
+  describe('getting all projects', function () {
+    it('has all data', function () {
+      var tray = {
+        url: 'url',
+        username: 'uname',
+        password: 'pword',
+        serverType: 'GO'
+      }
+
+      subject.fetchAll(tray)
+
+      expect(gateway.post).toBeCalledWith('/api/projects/all', tray)
+    })
   })
 
   describe('getting interesting projects', function () {

--- a/test/nevergreen/api/projects_test.clj
+++ b/test/nevergreen/api/projects_test.clj
@@ -10,14 +10,65 @@
 (def valid-url "http://someserver/cc.xml")
 (def password "any-password")
 
+(facts "it fetches projects"
+       (fact "with authentication"
+             (subject/fetch-tray {:url valid-url :username "a-user" :password "encrypted-password"}) => (contains (list (contains {:name       "project-1"
+                                                                                                                                   :prognosis  :sick
+                                                                                                                                   :project-id anything})))
+             (provided
+               (parser/get-projects ..stream.. anything) => [{:name "project-1" :prognosis :sick}]
+               (crypt/decrypt "encrypted-password") => password
+               (security/basic-auth-header "a-user" password) => ..auth-header..
+               (http/http-get valid-url ..auth-header..) => ..stream..))
+
+       (fact "without authentication"
+             (subject/fetch-tray {:url valid-url}) => (contains (list (contains {:name       "project-1"
+                                                                                 :prognosis  :sick
+                                                                                 :project-id anything})))
+             (provided
+               (parser/get-projects ..stream.. anything) => [{:name "project-1" :prognosis :sick}]
+               (http/http-get valid-url nil) => ..stream..
+               (crypt/decrypt anything) => anything :times 0
+               (security/basic-auth-header anything anything) => anything :times 0))
+
+       (fact "without authentication if blank username and password"
+             (subject/fetch-tray {:url valid-url :username "" :password ""}) => (contains (list (contains {:name       "project-1"
+                                                                                                           :prognosis  :sick
+                                                                                                           :project-id anything})))
+             (provided
+               (parser/get-projects ..stream.. anything) => [{:name "project-1" :prognosis :sick}]
+               (http/http-get valid-url nil) => ..stream..
+               (crypt/decrypt anything) => anything :times 0
+               (security/basic-auth-header anything anything) => anything :times 0)))
+
+(facts "it gets all projects"
+       (fact "throws exception if the url is not valid"
+             (subject/get-all [{:url "url"}]) => (throws Exception)
+             (provided
+               (subject/invalid-url? "url") => true))
+
+       (facts "uses pmap to parallelise the work"
+              (fact "if multiple projects are given"
+                    (subject/get-all [{:url "http://a"} {:url "http://b"}]) => irrelevant
+                    (provided
+                      (pmap anything anything) => irrelevant))
+
+              (fact "unless only one project is given"
+                    (subject/get-all [{:url "http://a"}]) => irrelevant
+                    (provided
+                      (pmap anything anything) => irrelevant :times 0
+                      (subject/fetch-tray anything) => irrelevant))))
+
 (facts "it gets interesting projects"
        (fact "throws exception if the url is not http[s]"
-             (subject/get-interesting [{:url "not-http"}]) => (throws Exception))
+             (subject/get-interesting [{:url "url"}]) => (throws Exception)
+             (provided
+               (subject/invalid-url? "url") => true))
 
        (fact "removes healthy projects"
              (subject/get-interesting [{:trayId "a-tray" :included ["project-1"] :url valid-url}]) => (list)
              (provided
-               (subject/get-all anything) => [{:project-id "project-1" :prognosis :healthy}]))
+               (subject/fetch-tray anything) => {:project-id "project-1" :prognosis :healthy}))
 
        (facts "uses pmap to parallelise the work"
               (fact "if multiple projects are given"
@@ -34,41 +85,7 @@
        (fact "handles no tray id being given"
              (subject/get-interesting [{:included ["project"] :url valid-url}]) => (list {:tray-id nil :project-id "project" :prognosis :sick})
              (provided
-               (subject/get-all anything) => [{:project-id "project" :prognosis :sick}])))
-
-(facts "it gets all projects"
-       (fact "throws exception if the url is not http[s]"
-             (subject/get-all [{:url "not-http"}]) => (throws Exception))
-
-       (fact "with authentication"
-             (subject/get-all {:url valid-url :username "a-user" :password "encrypted-password"}) => (contains (list (contains {:name       "project-1"
-                                                                                                                                :prognosis  :sick
-                                                                                                                                :project-id anything})))
-             (provided
-               (parser/get-projects ..stream.. anything) => [{:name "project-1" :prognosis :sick}]
-               (crypt/decrypt "encrypted-password") => password
-               (security/basic-auth-header "a-user" password) => ..auth-header..
-               (http/http-get valid-url ..auth-header..) => ..stream..))
-
-       (fact "without authentication"
-             (subject/get-all {:url valid-url}) => (contains (list (contains {:name       "project-1"
-                                                                              :prognosis  :sick
-                                                                              :project-id anything})))
-             (provided
-               (parser/get-projects ..stream.. anything) => [{:name "project-1" :prognosis :sick}]
-               (http/http-get valid-url nil) => ..stream..
-               (crypt/decrypt anything) => anything :times 0
-               (security/basic-auth-header anything anything) => anything :times 0))
-
-       (fact "without authentication if blank username and password"
-             (subject/get-all {:url valid-url :username "" :password ""}) => (contains (list (contains {:name       "project-1"
-                                                                                                        :prognosis  :sick
-                                                                                                        :project-id anything})))
-             (provided
-               (parser/get-projects ..stream.. anything) => [{:name "project-1" :prognosis :sick}]
-               (http/http-get valid-url nil) => ..stream..
-               (crypt/decrypt anything) => anything :times 0
-               (security/basic-auth-header anything anything) => anything :times 0)))
+               (subject/fetch-tray anything) => [{:project-id "project" :prognosis :sick}])))
 
 (facts "gets the server type"
        (fact "converts known server value to a symbol"


### PR DESCRIPTION
Resolves #96.

This changes `/api/projects/all` to take a list of trays, rather than a single tray, in order to make it more consistent with `/api/projects/interesting`.

The client edits just involve making the gateway compliant with the new API format, and then wrapping the call for the single tray (in `refreshTray`) to pass the tray as a list of one element. It seemed like a lot of extra work to take this further, and I didn't want to change too much.

Again, pushing my boundaries of Clojure, so any feedback would be much appreciated. ~~Also, I've not had the opportunity to test this with a CI that requires authentication (I'll try to do so tomorrow), so that's something I would recommend before this is merged.~~