### PR TITLE
Fixed up react addon warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "node-uuid": "1.4.7",
     "promise": "7.0.4",
     "react": "0.14.3",
+    "react-addons-linked-state-mixin": "^0.14.3",
+    "react-addons-test-utils": "^0.14.3",
     "react-router": "1.0.2",
     "reactify": "^1.1.1",
     "scale-text": "0.2.2",

--- a/src/js/views/export/exportSection.js
+++ b/src/js/views/export/exportSection.js
@@ -1,4 +1,5 @@
-var React = require('react/addons')
+var React = require('react')
+var LinkedStateMixin = require('react-addons-linked-state-mixin')
 var ValidationMessages = require('../general/validationMessages')
 var ConfigurationStore = require('../../stores/ConfigurationStore')
 var ConfigurationActions = require('../../actions/ConfigurationActions')
@@ -17,7 +18,7 @@ function getStateFromStore(currentImportData) {
 }
 
 module.exports = React.createClass({
-  mixins: [React.addons.LinkedStateMixin],
+  mixins: [LinkedStateMixin],
 
   getInitialState: function () {
     return getStateFromStore('')

--- a/src/js/views/success/addMessage.js
+++ b/src/js/views/success/addMessage.js
@@ -1,8 +1,9 @@
-var React = require('react/addons')
+var React = require('react')
+var LinkedStateMixin = require('react-addons-linked-state-mixin')
 var ValidationMessages = require('../general/validationMessages')
 
 module.exports = React.createClass({
-  mixins: [React.addons.LinkedStateMixin],
+  mixins: [LinkedStateMixin],
 
   propTypes: {
     addMessage: React.PropTypes.func.isRequired,

--- a/src/js/views/success/addedImages.js
+++ b/src/js/views/success/addedImages.js
@@ -1,4 +1,4 @@
-var React = require('react/addons')
+var React = require('react')
 var Image = require('./image')
 
 module.exports = React.createClass({

--- a/src/js/views/success/addedMessages.js
+++ b/src/js/views/success/addedMessages.js
@@ -1,4 +1,4 @@
-var React = require('react/addons')
+var React = require('react')
 var Message = require('./message')
 var AddMessage = require('./addMessage')
 

--- a/src/js/views/success/message.js
+++ b/src/js/views/success/message.js
@@ -1,4 +1,4 @@
-var React = require('react/addons')
+var React = require('react')
 var RemoveLink = require('./removeLink')
 
 module.exports = React.createClass({

--- a/src/js/views/success/successSection.js
+++ b/src/js/views/success/successSection.js
@@ -1,4 +1,4 @@
-var React = require('react/addons')
+var React = require('react')
 var AddedMessages = require('./addedMessages')
 var AddedImages = require('./addedImages')
 var AddMessage = require('./addMessage')

--- a/src/js/views/tracking/addTray.js
+++ b/src/js/views/tracking/addTray.js
@@ -1,8 +1,9 @@
-var React = require('react/addons')
+var React = require('react')
+var LinkedStateMixin = require('react-addons-linked-state-mixin')
 var ValidationMessages = require('../general/validationMessages')
 
 module.exports = React.createClass({
-  mixins: [React.addons.LinkedStateMixin],
+  mixins: [LinkedStateMixin],
 
   propTypes: {
     addTray: React.PropTypes.func.isRequired,

--- a/src/js/views/tracking/availableProject.js
+++ b/src/js/views/tracking/availableProject.js
@@ -1,4 +1,4 @@
-var React = require('react/addons')
+var React = require('react')
 
 module.exports = React.createClass({
   propTypes: {

--- a/src/js/views/tracking/trackingSection.js
+++ b/src/js/views/tracking/trackingSection.js
@@ -1,4 +1,4 @@
-var React = require('react/addons')
+var React = require('react')
 var AddTray = require('./addTray')
 var Tray = require('./tray')
 var TrayStore = require('../../stores/TrayStore')

--- a/src/js/views/tracking/traySettings.js
+++ b/src/js/views/tracking/traySettings.js
@@ -1,4 +1,4 @@
-var React = require('react/addons')
+var React = require('react')
 var _ = require('lodash')
 
 module.exports = React.createClass({

--- a/test/js/views/general/errorViewTest.js
+++ b/test/js/views/general/errorViewTest.js
@@ -9,8 +9,8 @@ describe('error view', function () {
   var React, TestUtils, ErrorView
 
   beforeEach(function () {
-    React = require('react/addons')
-    TestUtils = React.addons.TestUtils
+    React = require('react')
+    TestUtils = require('react-addons-test-utils')
     ErrorView = require('../../../../src/js/views/general/errorView.js')
   })
 

--- a/test/js/views/tracking/availableProjectTest.js
+++ b/test/js/views/tracking/availableProjectTest.js
@@ -4,8 +4,8 @@ describe('available project', function () {
   var React, TestUtils, AvailableProject, callback
 
   beforeEach(function () {
-    React = require('react/addons')
-    TestUtils = React.addons.TestUtils
+    React = require('react')
+    TestUtils = require('react-addons-test-utils')
     AvailableProject = require('../../../../src/js/views/tracking/availableProject.js')
 
     callback = jest.genMockFunction()


### PR DESCRIPTION
Every time I run the javascript tests, I get two warnings repeatedly. 

```
Warning: require('react/addons') is deprecated. Access using require('react-addons-{addon}') instead.
Warning: ReactDOMComponent: Do not access .getDOMNode() of a DOM node; instead, use the node directly. This DOM node was rendered by `exports`.
```

I've fixed the first one by changing the references to use [each addon package](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#major-changes), I struggled to no avail fixing up the second ones.