### PR TITLE
Converts spaces in success messages to non-breaking spaces

### DIFF
--- a/src/js/actions/SuccessActions.js
+++ b/src/js/actions/SuccessActions.js
@@ -8,12 +8,20 @@ const _addMessageValidation = {
   }
 }
 
+function isASentence(message) {
+  const numberOfLetters = (message.match(/[A-Za-z]/g) || []).length
+  return (numberOfLetters / message.length) > 0.3
+}
+
 function transformMessage(message) {
+  if (isASentence(message)) {
+    return message
+  }
+
   return message.replace(/ /g, String.fromCharCode(160))
 }
 
 module.exports = {
-
   addMessage(message) {
     const validationMessages = validate({message: message}, _addMessageValidation)
 

--- a/src/js/actions/SuccessActions.js
+++ b/src/js/actions/SuccessActions.js
@@ -8,6 +8,10 @@ const _addMessageValidation = {
   }
 }
 
+function transformMessage(message) {
+  return message.replace(/ /g, String.fromCharCode(160))
+}
+
 module.exports = {
 
   addMessage(message) {
@@ -22,7 +26,7 @@ module.exports = {
     } else {
       AppDispatcher.dispatch({
         type: Constants.MessageAdd,
-        message: message.replace(/ /g, String.fromCharCode(160))
+        message: transformMessage(message)
       })
     }
   },
@@ -30,7 +34,7 @@ module.exports = {
   removeMessage(message) {
     AppDispatcher.dispatch({
       type: Constants.MessageRemove,
-      message: message.replace(/ /g, String.fromCharCode(160))
+      message: transformMessage(message)
     })
   }
 

--- a/src/js/actions/SuccessActions.js
+++ b/src/js/actions/SuccessActions.js
@@ -22,7 +22,7 @@ module.exports = {
     } else {
       AppDispatcher.dispatch({
         type: Constants.MessageAdd,
-        message: message
+        message: message.replace(/ /g, String.fromCharCode(160))
       })
     }
   },
@@ -30,7 +30,7 @@ module.exports = {
   removeMessage(message) {
     AppDispatcher.dispatch({
       type: Constants.MessageRemove,
-      message: message
+      message: message.replace(/ /g, String.fromCharCode(160))
     })
   }
 

--- a/test/js/actions/SuccessActionsTest.js
+++ b/test/js/actions/SuccessActionsTest.js
@@ -46,12 +46,23 @@ describe('success actions', () => {
     })
   })
 
-  it('converts messages containing spaces to use non-breaking spaces', function () {
-    subject.addMessage('some message')
+  describe('dealing with spaces', function () {
+    it('converts messages which do not look like text to use non-breaking spaces', function () {
+      subject.addMessage('=(^ . ^)=')
 
-    expect(AppDispatcher.dispatch).toBeCalledWith({
-      type: Constants.MessageAdd,
-      message: 'some message'.replace(/ /g, String.fromCharCode(160))
+      expect(AppDispatcher.dispatch).toBeCalledWith({
+        type: Constants.MessageAdd,
+        message: '=(^ . ^)='.replace(/ /g, String.fromCharCode(160))
+      })
+    })
+
+    it('does not convert messages which look like text', function () {
+      subject.addMessage('some message')
+
+      expect(AppDispatcher.dispatch).toBeCalledWith({
+        type: Constants.MessageAdd,
+        message: 'some message'
+      })
     })
   })
 })

--- a/test/js/actions/SuccessActionsTest.js
+++ b/test/js/actions/SuccessActionsTest.js
@@ -12,6 +12,10 @@ describe('success actions', () => {
     validate = require('validate.js')
   })
 
+  it('should not change messages which do not need to change', () => {
+      expect('some-string').toEqual('some-string'.replace(/ /g, String.fromCharCode(160)))
+  })
+
   it('dispatches a invalid action for blank messages', () => {
     validate.mockReturnValue('some message')
 
@@ -39,6 +43,15 @@ describe('success actions', () => {
     expect(AppDispatcher.dispatch).toBeCalledWith({
       type: Constants.MessageRemove,
       message: '=(^.^)='
+    })
+  })
+
+  it('converts messages containing spaces to use non-breaking spaces', function () {
+    subject.addMessage('some message')
+
+    expect(AppDispatcher.dispatch).toBeCalledWith({
+      type: Constants.MessageAdd,
+      message: 'some message'.replace(/ /g, String.fromCharCode(160))
     })
   })
 })

--- a/test/js/actions/SuccessActionsTest.js
+++ b/test/js/actions/SuccessActionsTest.js
@@ -46,8 +46,8 @@ describe('success actions', () => {
     })
   })
 
-  describe('dealing with spaces', function () {
-    it('converts messages which do not look like text to use non-breaking spaces', function () {
+  describe('dealing with spaces', () => {
+    it('converts messages which do not look like text to use non-breaking spaces', () => {
       subject.addMessage('=(^ . ^)=')
 
       expect(AppDispatcher.dispatch).toBeCalledWith({
@@ -56,7 +56,7 @@ describe('success actions', () => {
       })
     })
 
-    it('does not convert messages which look like text', function () {
+    it('does not convert messages which look like text', () => {
       subject.addMessage('some message')
 
       expect(AppDispatcher.dispatch).toBeCalledWith({


### PR DESCRIPTION
![ng](https://cloud.githubusercontent.com/assets/653864/11870478/16c7c45c-a4c0-11e5-8c48-1ffa5763177f.gif)

This is a rather ham-fisted approach of dealing with success messages breaking across lines (#65). It just converts all spaces in success messages into non-breaking spaces (`&nbsp;`.) I could take this further by trying to be clever at distinguishing between words and symbols (>60% non-A-Za-z, non-breaking spaces.)

What do you think? Is the non-breaking text particularly bad looking? Is it worth me looking at trying to distinguish before we convert the spaces?