### PR TITLE
Allow all subsections to be hidden

### DIFF
--- a/src/js/views/display/displaySection.js
+++ b/src/js/views/display/displaySection.js
@@ -1,5 +1,6 @@
 const React = require('react')
 const ConfigOption = require('./configOption')
+const Container = require('../general/container')
 const DisplayStore = require('../../stores/DisplayStore')
 const DisplayActions = require('../../actions/DisplayActions')
 
@@ -31,15 +32,13 @@ module.exports = React.createClass({
   render() {
     return (
       <section className='dashboard-main-section'>
-        <h2 className='visually-hidden'>Display</h2>
-        <section className='sub-section'>
-          <h3 className='section-title'>Display Settings</h3>
+        <Container title='Display Settings'>
           <fieldset className='settings-list'>
             <ConfigOption name='Show broken build timers'
                           enabled={this.state.showBrokenBuildTimers}
                           onToggle={this._onToggle}/>
           </fieldset>
-        </section>
+        </Container>
       </section>
     )
   },

--- a/src/js/views/export/export.js
+++ b/src/js/views/export/export.js
@@ -2,6 +2,7 @@ const React = require('react')
 const ValidationMessages = require('../general/validationMessages')
 const InfoMessages = require('../general/InfoMessages')
 const Clipboard = require('clipboard')
+const Container = require('../general/container')
 const Loading = require('../general/loading')
 
 module.exports = React.createClass({
@@ -59,10 +60,9 @@ module.exports = React.createClass({
     )
 
     return (
-      <section className='sub-section'>
-        <h3 className='section-title'>Export</h3>
+      <Container title='Export'>
         {this.props.loading ? <Loading/> : content}
-      </section>
+      </Container>
     )
   }
 })

--- a/src/js/views/export/import.js
+++ b/src/js/views/export/import.js
@@ -3,6 +3,7 @@ const LinkedStateMixin = require('react-addons-linked-state-mixin')
 const ValidationMessages = require('../general/validationMessages')
 const InfoMessages = require('../general/InfoMessages')
 const ConfigurationActions = require('../../actions/ConfigurationActions')
+const Container = require('../general/container')
 const Loading = require('../general/loading')
 
 module.exports = React.createClass({
@@ -40,10 +41,9 @@ module.exports = React.createClass({
     )
 
     return (
-      <section className='sub-section'>
-        <h3 className='section-title'>Import</h3>
+      <Container title='Import'>
         {this.props.loading ? <Loading/> : content}
-      </section>
+      </Container>
     )
   },
 

--- a/src/js/views/general/container.js
+++ b/src/js/views/general/container.js
@@ -1,0 +1,46 @@
+const React = require('react')
+
+module.exports = React.createClass({
+    displayName: 'Container',
+
+    propTypes: {
+      name: React.PropTypes.string.isRequired
+    },
+
+    getInitialState() {
+      return {
+        hidden: false
+      }
+    },
+
+    _toggleHidden() {
+      this.setState({
+        hidden: !this.state.hidden
+      })
+    },
+
+    _showHideLabel() {
+        return this.state.hidden ? 'Show pane' : 'Hide pane'
+    },
+
+    _renderShowHideToggle() {
+      return (
+        <button className='tray-hidden-button' onClick={this._toggleHidden} title={this._showHideLabel()}>
+          <span className={'icon-' + (this.state.hidden ? 'circle-down' : 'circle-up') }/>
+          <span className='visually-hidden'>{this._showHideLabel()}</span>
+        </button>
+      )
+    },
+
+    render() {
+      return (
+        <section className='sub-section'>
+          <h3 className='section-title'>
+            {this._renderShowHideToggle()}
+            {this.props.title}
+          </h3>
+          {this.state.hidden ? '' : this.props.children}
+        </section>
+      )
+    }
+})

--- a/src/js/views/help/helpSection.js
+++ b/src/js/views/help/helpSection.js
@@ -1,4 +1,5 @@
 const React = require('react')
+const Container = require('../general/container')
 
 module.exports = React.createClass({
   displayName: 'HelpSection',
@@ -7,9 +8,8 @@ module.exports = React.createClass({
     return (
       <section className='dashboard-main-section'>
         <h2 className='visually-hidden'>Help</h2>
-        <section className='sub-section'>
-          <h3 className='section-title'>Monitor</h3>
 
+        <Container title='Monitor'>
           <div className='help-contents'>
             <table className='help-tracking-table'>
               <thead>
@@ -35,11 +35,9 @@ module.exports = React.createClass({
             </table>
             <p className="help-text">If nothing is broken or building then a random success message will be shown.</p>
           </div>
-        </section>
+        </Container>
 
-        <section className='sub-section'>
-          <h3 className='section-title'>Tracking</h3>
-
+        <Container title='Tracking'>
           <div className='help-contents'>
             <p className="help-text">To get started you need to enter the URL to your cctray xml file. Where it lives
               depends on your CI Server of choice: </p>
@@ -100,11 +98,9 @@ module.exports = React.createClass({
             <p className="help-text">If you are just checking us out then you can use the Apache projects cctray at:
               https://builds.apache.org/cc.xml</p>
           </div>
-        </section>
+        </Container>
 
-        <section className='sub-section'>
-          <h3 className='section-title'>Success</h3>
-
+        <Container title='Success'>
           <div className='help-contents'>
             <p className="help-text">You can add text or image urls, these will get displayed when no projects are
               broken or building on the monitor page. Images are previewed in a 16:9 ratio which is how they would
@@ -119,10 +115,9 @@ module.exports = React.createClass({
               like jelly guy! ༼つ◕_◕༽つ
             </p>
           </div>
-        </section>
+        </Container>
 
-        <section role='seealso' className='sub-section'>
-          <h3 className='section-title'>Additional Links</h3>
+        <Container title='Additional Links'>
           <ul className='help-links'>
             <li>
               <span className='help-link-icon icon-github4'/>
@@ -140,7 +135,7 @@ module.exports = React.createClass({
               done right".
             </li>
           </ul>
-        </section>
+        </Container>
       </section>
     )
   }

--- a/src/js/views/success/addedImages.js
+++ b/src/js/views/success/addedImages.js
@@ -1,4 +1,5 @@
 const React = require('react')
+const Container = require('../general/container')
 const RemoveLink = require('./removeLink')
 
 module.exports = React.createClass({
@@ -11,8 +12,7 @@ module.exports = React.createClass({
 
   render() {
     return (
-      <section className='sub-section'>
-        <h3 className='section-title'>Images</h3>
+      <Container title='Images'>
         <ul className='success-list success-images-list'>
           {
             this.props.messages.map(message => {
@@ -25,7 +25,7 @@ module.exports = React.createClass({
             })
           }
         </ul>
-      </section>
+      </Container>
     )
   }
 })

--- a/src/js/views/success/addedMessages.js
+++ b/src/js/views/success/addedMessages.js
@@ -1,4 +1,5 @@
 const React = require('react')
+const Container = require('../general/container')
 const RemoveLink = require('./removeLink')
 
 module.exports = React.createClass({
@@ -11,8 +12,7 @@ module.exports = React.createClass({
 
   render() {
     return (
-      <section className='sub-section'>
-        <h3 className='section-title'>Messages</h3>
+      <Container title='Messages'>
         <ul className='success-list success-text-list'>
           {
             this.props.messages.map(message => {
@@ -25,7 +25,7 @@ module.exports = React.createClass({
             })
           }
         </ul>
-      </section>
+      </Container>
     )
   }
 })

--- a/src/js/views/tracking/tray.js
+++ b/src/js/views/tracking/tray.js
@@ -1,4 +1,5 @@
 const React = require('react')
+const Container = require('../general/container')
 const Projects = require('./projects')
 const TraySettings = require('./traySettings')
 const Loading = require('../general/loading')
@@ -39,14 +40,12 @@ module.exports = React.createClass({
   },
 
   render() {
-    let content
+    let subContent
 
     if (this.state.showSettings) {
-      content =
+      subContent =
         <TraySettings tray={this.props.tray} removeTray={this.props.removeTray} updateTray={this.props.updateTray}/>
     } else {
-      let subContent
-
       if (this.props.tray.fetching) {
         subContent = <Loading/>
       } else if (this.props.tray.error) {
@@ -58,51 +57,37 @@ module.exports = React.createClass({
       } else {
         subContent = <Projects trayId={this.props.tray.trayId}/>
       }
+    }
 
-      content = (
+    return (
+      <Container title={this.props.tray.url}>
         <div>
-          <div className='tray-refresh'>
+          <div className='tray-sub-bar'>
+            <button className='button' onClick={this._toggleSettingsView} title='Toggle settings'>
+              <span className={'icon-' + (this.state.showSettings ? 'list' : 'cog') }/>
+              <span className='text-with-icon'>{this._toggleSettingsLabel()}</span>
+            </button>
             <button className='button' onClick={this.props.refreshTray}>
               <span className='icon-loop2'/>
               <span className='text-with-icon'>Refresh tray</span>
             </button>
             <span className='tray-refresh-last-fetch'>last refreshed {this.state.lastFetched} ago</span>
           </div>
-          {subContent}
+          <div>
+            {subContent}
+          </div>
         </div>
-      )
-    }
-
-    const hideText = this.state.hidden ? 'expand tray' : 'collapse tray'
-    const settingsText = this.state.showSettings ? 'show projects' : 'show settings'
-
-    return (
-      <section className='tray'>
-        <div className='tray-title-container'>
-          <button className='tray-hidden-button' onClick={this._toggleHidden} title={hideText}>
-            <span className={'icon-' + (this.state.hidden ? 'circle-down' : 'circle-up') }/>
-            <span className='visually-hidden'>{hideText}</span>
-          </button>
-          <h3 className='tray-title'>{this.props.tray.url}</h3>
-          <button className='tray-settings-button' onClick={this._toggleSettingsView} title={settingsText}>
-            <span className={'icon-' + (this.state.showSettings ? 'list' : 'cog') }/>
-            <span className='visually-hidden'>{settingsText}</span>
-          </button>
-        </div>
-        {this.state.hidden ? '' : content}
-      </section>
+      </Container>
     )
+  },
+
+  _toggleSettingsLabel() {
+      return this.state.showSettings ? 'Show projects' : 'Show settings'
   },
 
   _toggleSettingsView() {
     this.setState({
       showSettings: !this.state.showSettings
-    })
-  },
-
-  _toggleHidden() {
-    this.setState({
-      hidden: !this.state.hidden
     })
   },
 

--- a/src/scss/_general.scss
+++ b/src/scss/_general.scss
@@ -18,12 +18,13 @@
   font-size: 1.5rem;
   border: 1px solid $mid-grey;
   background-color: white;
+  margin-bottom: 1em;
 }
 
 .section-title {
   font-size: 1.5rem;
   font-weight: 400;
-  padding: 0.5em 1em;
+  padding: 0.5em;
   background: $mid-grey;
   color: white;
   text-overflow: ellipsis;

--- a/src/scss/_tracking.scss
+++ b/src/scss/_tracking.scss
@@ -111,12 +111,10 @@
 }
 
 .tray-hidden-button {
-  font-size: 1.8rem;
+  font-size: 1.2rem;
   display: inline;
-  padding: 0;
   border: none;
   background: none;
-  color: white;
   margin-right: 0.5em;
 
   &:hover {
@@ -124,11 +122,12 @@
   }
 }
 
-.tray-refresh {
-  margin: 1em 1em 0 1em;
+.tray-sub-bar {
+  background: $light-grey;
+  color: $mid-grey;
+  padding: 0.3em;
 }
 
 .tray-refresh-last-fetch {
-  color: $mid-grey;
   margin-left: 1em;
 }


### PR DESCRIPTION
This pull request, made to resolve #111, creates a common `Container` component, and puts everything that was in a grey box inside it. This has also meant all things which use `Container` are now able to be hidden and expanded.

<img width="274" alt="screen shot 2016-01-24 at 21 07 03" src="https://cloud.githubusercontent.com/assets/653864/12538929/7f7b10bc-c2de-11e5-8bbc-a06f7be0b380.png">

One of the caveats with this is that I either had to create a "right hand side" customisation option of the common container, or move the tray settings button inside the container itself. I chose the latter because I didn't want to deal with a bunch of complex conditionals for one subsection.

##### Before

<img width="1097" alt="screen shot 2016-01-24 at 21 09 43" src="https://cloud.githubusercontent.com/assets/653864/12538941/d1d627b6-c2de-11e5-9e12-20b09fb9c4c8.png">

##### After

<img width="1036" alt="screen shot 2016-01-24 at 21 06 52" src="https://cloud.githubusercontent.com/assets/653864/12538928/7d368142-c2de-11e5-9b89-9f2a35d29a2f.png">

<img width="1034" alt="screen shot 2016-01-24 at 21 12 44" src="https://cloud.githubusercontent.com/assets/653864/12538955/42258138-c2df-11e5-8071-caffb0cd8b62.png">

