### PR TITLE
Configurable IP address binding

### DIFF
--- a/src/nevergreen/app.clj
+++ b/src/nevergreen/app.clj
@@ -19,4 +19,4 @@
         (wrap-routes wrap-app-middleware))))
 
 (defn -main []
-  (http-kit/run-server all-routes {:port (config/port)}))
+  (http-kit/run-server all-routes {:ip (config/ip) :port (config/port)}))

--- a/src/nevergreen/config.clj
+++ b/src/nevergreen/config.clj
@@ -5,6 +5,7 @@
 
 (def ^:private aes-key-length 16)
 (def default-aes-key "abcdefghijklmnop")
+(def default-ip "0.0.0.0")
 
 (def ^:private use-default-key
   (delay
@@ -16,6 +17,9 @@
 
 (defn port []
   (Integer. (or (env :port) 5000)))
+
+(defn ip []
+  (or (env :ip) default-ip))
 
 (defn aes-key []
   (let [aes-key (env :aes-key)]

--- a/test/nevergreen/config_test.clj
+++ b/test/nevergreen/config_test.clj
@@ -29,3 +29,14 @@
              (subject/aes-key) => (throws RuntimeException)
              (provided
                (env :aes-key) => "not-long-enough")))
+
+(facts "ip"
+       (fact "from env"
+             (subject/ip) => "localhost"
+             (provided
+               (env :ip) => "localhost"))
+
+       (fact "defaults to 0.0.0.0"
+             (subject/ip) => "0.0.0.0"
+             (provided
+               (env :ip) => nil)))


### PR DESCRIPTION
Adds ability to bind nevergreen to user-specified IP to allow running in more constrained environments. For example some PaaS solutions specify to which IP application should be bound. This obviously stops nevergreen from running. 

This can be easily fixed by adding an option to define IP to which nevergreen will be bound - with a reasonable default (following "0.0.0.0" as per http-kit defaults).

This pull request adds such capability.