### PR TITLE
Add settings to display tray name in monitor

### DIFF
--- a/src/client/audio-visual/AudioVisual.js
+++ b/src/client/audio-visual/AudioVisual.js
@@ -20,6 +20,7 @@ class AudioVisual extends Component {
 
   render() {
     const toggleBrokenBuilds = (newValue) => this.props.setBrokenBuildTimers(newValue)
+    const toggleTrayName = (newValue) => this.props.setTrayNameToggled(newValue)
     const toggleBrokenSounds = (newValue) => this.props.setBrokenBuildSounds(newValue)
     const setSoundFx = () => this.props.setBrokenBuildSoundFx(this.refs.soundFx.value)
     const testSoundFx = () => {
@@ -34,6 +35,9 @@ class AudioVisual extends Component {
       <section className='audio-visual'>
         <Container title='Display Settings'>
           <fieldset className='settings-list'>
+            <ConfigOption name='Show tray name'
+                          enabled={this.props.showTrayName}
+                          onToggle={toggleTrayName}/>
             <ConfigOption name='Show broken build timers'
                           enabled={this.props.showBrokenBuildTimers}
                           onToggle={toggleBrokenBuilds}/>
@@ -64,9 +68,11 @@ class AudioVisual extends Component {
 
 AudioVisual.propTypes = {
   showBrokenBuildTimers: PropTypes.bool.isRequired,
+  showTrayName: PropTypes.bool.isRequired,
   showBrokenBuildSounds: PropTypes.bool.isRequired,
   brokenBuildSoundFx: PropTypes.string.isRequired,
   setBrokenBuildTimers: PropTypes.func.isRequired,
+  setTrayNameToggled: PropTypes.func.isRequired,
   setBrokenBuildSounds: PropTypes.func.isRequired,
   setBrokenBuildSoundFx: PropTypes.func.isRequired
 }

--- a/src/client/audio-visual/AudioVisualActions.js
+++ b/src/client/audio-visual/AudioVisualActions.js
@@ -8,6 +8,14 @@ export function setBrokenBuildTimers(value) {
   })
 }
 
+export const TrayNameToggled = 'tray-name-toggled'
+export function setTrayNameToggled(value) {
+  AppDispatcher.dispatch({
+    type: TrayNameToggled,
+    value
+  })
+}
+
 export const BrokenBuildSoundsToggled = 'broken-build-sounds-toggled'
 export function setBrokenBuildSounds(value) {
   AppDispatcher.dispatch({

--- a/src/client/audio-visual/AudioVisualContainer.js
+++ b/src/client/audio-visual/AudioVisualContainer.js
@@ -1,14 +1,16 @@
 import React, {Component} from 'react'
 import DisplayStore from '../stores/DisplayStore'
-import {setBrokenBuildSoundFx, setBrokenBuildSounds, setBrokenBuildTimers} from './AudioVisualActions'
+import {setBrokenBuildSoundFx, setBrokenBuildSounds, setBrokenBuildTimers, setTrayNameToggled} from './AudioVisualActions'
 import AudioVisual from './AudioVisual'
 
 function mapStateToProps() {
   return {
     showBrokenBuildTimers: DisplayStore.areBrokenBuildTimersEnabled(),
+    showTrayName: DisplayStore.areTrayNameEnabled(),
     showBrokenBuildSounds: DisplayStore.areBrokenBuildSoundsEnabled(),
     brokenBuildSoundFx: DisplayStore.brokenBuildSoundFx(),
     setBrokenBuildTimers,
+    setTrayNameToggled,
     setBrokenBuildSounds,
     setBrokenBuildSoundFx
   }

--- a/src/client/common/gateways/ProjectsGateway.js
+++ b/src/client/common/gateways/ProjectsGateway.js
@@ -27,7 +27,7 @@ export function interesting(trays, selected) {
 
   return post('/api/projects/interesting', data).then((projects) => {
     return projects.map((project) => {
-      project.trayName = trays.find(tray => tray.trayId === project.trayId).name
+      project.trayName = trays.find((tray) => tray.trayId === project.trayId).name
       return project
     })
   })

--- a/src/client/common/gateways/ProjectsGateway.js
+++ b/src/client/common/gateways/ProjectsGateway.js
@@ -25,5 +25,10 @@ export function interesting(trays, selected) {
     }
   })
 
-  return post('/api/projects/interesting', data)
+  return post('/api/projects/interesting', data).then((projects) => {
+    return projects.map((project) => {
+      project.trayName = trays.find(tray => tray.trayId === project.trayId).name
+      return project
+    })
+  })
 }

--- a/src/client/monitor/InterestingProject.js
+++ b/src/client/monitor/InterestingProject.js
@@ -13,7 +13,7 @@ class InterestingProject extends Component {
     const timeBrokenLabel = _.isEmpty(_.trim(this.props.lastBuildTime)) ? '??' : moment(this.props.lastBuildTime).fromNow(true)
     const timeBroken = this.props.showBrokenBuildTimers && isSick ?
       <span className='time-broken'> {timeBrokenLabel}</span> : null
-    const displayName = this.props.showTrayName ? `${this.props.showTrayName} >> ${this.props.name}` : this.props.name
+    const displayName = this.props.showTrayName ? `${this.props.trayName} >> ${this.props.name}` : this.props.name
 
     return (
       <li className={`interesting-project ${this.props.prognosis}`}>

--- a/src/client/monitor/InterestingProject.js
+++ b/src/client/monitor/InterestingProject.js
@@ -13,12 +13,13 @@ class InterestingProject extends Component {
     const timeBrokenLabel = _.isEmpty(_.trim(this.props.lastBuildTime)) ? '??' : moment(this.props.lastBuildTime).fromNow(true)
     const timeBroken = this.props.showBrokenBuildTimers && isSick ?
       <span className='time-broken'> {timeBrokenLabel}</span> : null
+    const displayName = this.props.showTrayName ? `${this.props.showTrayName} >> ${this.props.name}` : this.props.name
 
     return (
       <li className={`interesting-project ${this.props.prognosis}`}>
         <div className='monitor-outer-container'>
           <div className='monitor-inner-container'>
-            <span className='monitor-project-name'>{this.props.name}</span>
+            <span className='monitor-project-name'>{displayName}</span>
             {timeBroken}
           </div>
         </div>
@@ -30,8 +31,10 @@ class InterestingProject extends Component {
 InterestingProject.propTypes = {
   prognosis: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  trayName: PropTypes.string,
   lastBuildTime: PropTypes.string.isRequired,
-  showBrokenBuildTimers: PropTypes.bool
+  showBrokenBuildTimers: PropTypes.bool,
+  showTrayName: PropTypes.bool
 }
 
 export default InterestingProject

--- a/src/client/monitor/InterestingProjects.js
+++ b/src/client/monitor/InterestingProjects.js
@@ -37,7 +37,8 @@ class InterestingProjects extends Component {
           {
             this.props.projects.map((project) => {
               return <InterestingProject {...project} key={project.webUrl}
-                                                      showBrokenBuildTimers={this.props.showBrokenBuildTimers}/>
+                                                      showBrokenBuildTimers={this.props.showBrokenBuildTimers}
+                                                      showTrayName={this.props.showTrayName}/>
             })
           }
         </ul>
@@ -52,6 +53,7 @@ InterestingProjects.propTypes = {
     webUrl: PropTypes.string.isRequired
   })).isRequired,
   showBrokenBuildTimers: PropTypes.bool,
+  showTrayName: PropTypes.bool,
   playBrokenBuildSounds: PropTypes.bool,
   brokenBuildFx: PropTypes.string
 }

--- a/src/client/monitor/Monitor.js
+++ b/src/client/monitor/Monitor.js
@@ -31,6 +31,7 @@ class Monitor extends Component {
       content =
         <InterestingProjects projects={this.props.projects}
                              showBrokenBuildTimers={this.props.showBrokenBuildTimers}
+                             showTrayName={this.props.showTrayName}
                              playBrokenBuildSounds={this.props.playBrokenBuildSounds}
                              brokenBuildFx={this.props.brokenBuildFx}/>
 
@@ -58,6 +59,7 @@ Monitor.propTypes = {
   stopPolling: PropTypes.func.isRequired,
   showMenu: PropTypes.func.isRequired,
   showBrokenBuildTimers: PropTypes.bool,
+  showTrayName: PropTypes.bool,
   playBrokenBuildSounds: PropTypes.bool,
   brokenBuildFx: PropTypes.string,
   successMessage: PropTypes.func.isRequired

--- a/src/client/monitor/MonitorContainer.js
+++ b/src/client/monitor/MonitorContainer.js
@@ -14,6 +14,7 @@ function getStateFromStore() {
     loading: false,
     brokenBuildSoundEnabled: DisplayStore.areBrokenBuildSoundsEnabled(),
     showBrokenBuildTimers: DisplayStore.areBrokenBuildTimersEnabled(),
+    showTrayName: DisplayStore.areTrayNameEnabled(),
     playBrokenBuildSounds: DisplayStore.areBrokenBuildSoundsEnabled(),
     brokenBuildFx: DisplayStore.brokenBuildSoundFx(),
     successMessage: SuccessStore.randomMessage

--- a/src/client/stores/DisplayStore.js
+++ b/src/client/stores/DisplayStore.js
@@ -4,6 +4,7 @@ import {AppInit} from '../NevergreenActions'
 import {IMPORTED_DATA} from '../backup/BackupActions'
 import {
   BrokenBuildTimersChanged,
+  TrayNameToggled,
   BrokenBuildSoundsToggled,
   BrokenBuildSoundFx
 } from '../audio-visual/AudioVisualActions'
@@ -23,6 +24,7 @@ const dispatchToken = AppDispatcher.register((action) => {
     {
       _storeState = Object.assign({
         showBrokenBuildTimers: false,
+        showTrayName: false,
         showBrokenBuildSounds: false,
         brokenBuildSoundFx: defaultBrokenBuildSoundFx
       }, action.configuration[storageKey])
@@ -36,6 +38,11 @@ const dispatchToken = AppDispatcher.register((action) => {
     case BrokenBuildTimersChanged:
     {
       _storeState.showBrokenBuildTimers = action.value === true
+      break
+    }
+    case TrayNameToggled:
+    {
+      _storeState.showTrayName = action.value === true
       break
     }
     case BrokenBuildSoundsToggled:
@@ -64,6 +71,10 @@ module.exports = {
 
   areBrokenBuildTimersEnabled() {
     return _storeState.showBrokenBuildTimers
+  },
+
+  areTrayNameEnabled() {
+    return _storeState.showTrayName
   },
 
   areBrokenBuildSoundsEnabled() {

--- a/src/client/stores/InterestingProjectsStore.js
+++ b/src/client/stores/InterestingProjectsStore.js
@@ -15,6 +15,7 @@ function getName(apiProject) {
 function toProject(apiProject) {
   return {
     projectId: apiProject.projectId,
+    trayName: apiProject.trayName,
     name: getName(apiProject),
     prognosis: apiProject.prognosis,
     lastBuildTime: apiProject.lastBuildTime

--- a/test/client/audio-visual/AudioVisualActionsTest.js
+++ b/test/client/audio-visual/AudioVisualActionsTest.js
@@ -25,6 +25,15 @@ describe('audio visual actions', () => {
     })
   })
 
+  it('dispatches an action for tray name toggled', () => {
+    subject.setTrayNameToggled('some-value')
+
+    expect(AppDispatcher.dispatch).to.have.been.calledWith({
+      type: subject.TrayNameToggled,
+      value: 'some-value'
+    })
+  })
+
   it('dispatches an action for the broken build sounds toggled', () => {
     subject.setBrokenBuildSounds('toggle on')
 

--- a/test/client/common/gateways/ProjectsGatewayTest.js
+++ b/test/client/common/gateways/ProjectsGatewayTest.js
@@ -14,7 +14,7 @@ describe('projects gateway', () => {
   })
 
   beforeEach(() => {
-    Gateway.post = sinon.spy()
+    Gateway.post = sinon.stub().returns(new Promise(() => {}, () => {}))
   })
 
   describe('getting all projects', () => {

--- a/test/client/common/gateways/ProjectsGatewayTest.js
+++ b/test/client/common/gateways/ProjectsGatewayTest.js
@@ -6,7 +6,7 @@ import proxyquire from 'proxyquire'
 
 describe('projects gateway', () => {
 
-  let subject, Gateway
+  let subject, Gateway, projects, promised
 
   before(() => {
     Gateway = {}
@@ -14,7 +14,20 @@ describe('projects gateway', () => {
   })
 
   beforeEach(() => {
-    Gateway.post = sinon.stub().returns(new Promise(() => {}, () => {}))
+    projects = [{
+      trayId: 'id',
+      projectId: 'some-id',
+      name: 'name',
+      stage: 'stage',
+      prognosis: 'some-prognosis',
+      lastBuildTime: 'some-last-build-time'
+    }]
+    promised = new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(projects)
+      }, 0)
+    })
+    Gateway.post = sinon.stub().returns(promised)
   })
 
   describe('getting all projects', () => {
@@ -42,6 +55,7 @@ describe('projects gateway', () => {
       const selected = {id: ['some-project-id']}
       const tray = {
         trayId: 'id',
+        name: 'foo',
         url: 'url',
         username: 'uname',
         password: 'pword',
@@ -61,6 +75,31 @@ describe('projects gateway', () => {
       }]
 
       expect(Gateway.post).to.have.been.calledWith('/api/projects/interesting', data)
+    })
+
+    it('injects tray name into interesting projects', (done) => {
+      const selected = {id: ['some-project-id']}
+      const trays = [{
+        trayId: 'id',
+        name: 'foo',
+        url: 'url',
+        username: 'uname',
+        password: 'pword',
+        serverType: 'GO'
+      }]
+
+      subject.interesting(trays, selected).then((data) => {
+        expect(data).to.deep.equal([{
+          trayId: 'id',
+          trayName: 'foo',
+          projectId: 'some-id',
+          name: 'name',
+          stage: 'stage',
+          prognosis: 'some-prognosis',
+          lastBuildTime: 'some-last-build-time'
+        }])
+        done()
+      })
     })
   })
 })

--- a/test/client/monitor/InterestingProjectTest.js
+++ b/test/client/monitor/InterestingProjectTest.js
@@ -1,0 +1,56 @@
+import '../UnitSpec'
+import {describe, it, beforeEach} from 'mocha'
+import {expect} from 'chai'
+import React from 'react'
+import TestUtils from 'react-addons-test-utils'
+import InterestingProject from '../../../src/client/monitor/InterestingProject'
+
+describe('InterestingProject component', () => {
+  let renderer, project
+
+  beforeEach(() => {
+    project = {
+      trayName: 'foo',
+      name: 'name',
+      prognosis: 'some-prognosis',
+      lastBuildTime: '10h'
+    }
+    renderer = TestUtils.createRenderer()
+  })
+
+  it('renders both tray name and project name if showTrayName is true', () => {
+    renderer.render(
+      <InterestingProject {...project} showBrokenBuildTimers={true} showTrayName={true}/>
+    )
+
+    let output = renderer.getRenderOutput()
+    expect(output).to.deep.equal(
+      <li className='interesting-project some-prognosis'>
+        <div className='monitor-outer-container'>
+          <div className='monitor-inner-container'>
+            <span className='monitor-project-name'>foo >> name</span>
+            {null}
+          </div>
+        </div>
+      </li>
+    )
+  })
+
+  it('renders only project name if showTrayName is false', () => {
+    renderer.render(
+      <InterestingProject {...project} showBrokenBuildTimers={true} showTrayName={false}/>
+    )
+
+    let output = renderer.getRenderOutput()
+    expect(output).to.deep.equal(
+      <li className='interesting-project some-prognosis'>
+        <div className='monitor-outer-container'>
+          <div className='monitor-inner-container'>
+            <span className='monitor-project-name'>name</span>
+            {null}
+          </div>
+        </div>
+      </li>
+    )
+  })
+})

--- a/test/client/stores/DisplayStoreTest.js
+++ b/test/client/stores/DisplayStoreTest.js
@@ -6,6 +6,7 @@ import proxyquire from 'proxyquire'
 import {AppInit} from '../../../src/client/NevergreenActions'
 import {
   BrokenBuildTimersChanged,
+  TrayNameToggled,
   BrokenBuildSoundsToggled,
   BrokenBuildSoundFx
 } from '../../../src/client/audio-visual/AudioVisualActions'
@@ -22,7 +23,7 @@ describe('display store', () => {
 
     callback = AppDispatcher.register.getCall(0).args[0]
   })
-  
+
   beforeEach(() => {
     AppDispatcher.dispatch = sinon.spy()
 
@@ -56,6 +57,30 @@ describe('display store', () => {
           value: 'a string'
         })
         expect(subject.areBrokenBuildTimersEnabled()).to.be.false
+      }
+    )
+  })
+
+  describe('are tray name toggled', () => {
+    it('returns false by default', () => {
+      expect(subject.areTrayNameEnabled()).to.be.false
+    })
+
+    it('returns true when the callback changes the value to true', () => {
+      callback({
+        type: TrayNameToggled,
+        value: true
+      })
+
+      expect(subject.areTrayNameEnabled()).to.be.true
+    })
+
+    it('return false when the callback changes the value to anything else', () => {
+        callback({
+          type: TrayNameToggled,
+          value: 'a string'
+        })
+        expect(subject.areTrayNameEnabled()).to.be.false
       }
     )
   })

--- a/test/client/stores/InterestingProjectsStoreTest.js
+++ b/test/client/stores/InterestingProjectsStoreTest.js
@@ -19,10 +19,10 @@ describe('interesting projects store', () => {
 
     callback = AppDispatcher.register.getCall(0).args[0]
   })
-  
+
   beforeEach(() => {
     AppDispatcher.dispatch = sinon.spy()
-    
+
     callback({
       type: AppInit,
       configuration: {}
@@ -45,6 +45,7 @@ describe('interesting projects store', () => {
     callback({
       type: INTERESTING_PROJECTS,
       projects: [{
+        trayName: 'tray-name',
         projectId: 'some-id',
         name: 'name',
         stage: 'stage',
@@ -53,6 +54,7 @@ describe('interesting projects store', () => {
       }]
     })
     expect(subject.getAll()).to.deep.equal([{
+      trayName: 'tray-name',
       projectId: 'some-id',
       name: 'name stage',
       prognosis: 'some-prognosis',


### PR DESCRIPTION
This PR is to add option to show tray name along with project name in monitor view.

![Audio/Visual settings](https://www.evernote.com/shard/s232/sh/971e5209-62f0-4ea5-80e0-e5a6f79c116d/d9f3cbe33901e04b/res/0715eb0a-2b1b-454e-8fb7-b1f31e550ca1/skitch.png?resizeSmall&width=832)

The purpose of this feature is to help distinguishing between projects that share same name from multiple tracking urls.

![Monitor with tray name](https://www.evernote.com/shard/s232/sh/5797fcb9-3154-416c-8bcf-c17819ddb1c1/50ce26baf5383dbb/res/c537008b-b6d6-4b8c-abb1-66fc104df67a/skitch.png?resizeSmall&width=832)

Cheers, Vinh :)