### PR TITLE
Optionally show build label on monitor

### DIFF
--- a/ci_stub_server/cctray.xml
+++ b/ci_stub_server/cctray.xml
@@ -1,7 +1,7 @@
 <Projects>
-  <Project name="success-sleeping-project" activity="Sleeping" lastBuildStatus="Success" lastBuildTime="2015-12-09T10:31:10Z" webUrl="1"/>
-  <Project name="success-building-project" activity="Building" lastBuildStatus="Success" lastBuildTime="2015-12-09T10:31:10Z" webUrl="2"/>
-  <Project name="failure_sleeping_project" activity="Sleeping" lastBuildStatus="Failure" lastBuildTime="2015-12-09T10:31:10Z" webUrl="3"/>
-  <Project name="failure_building_project" activity="Building" lastBuildStatus="Failure" lastBuildTime="2015-12-09T10:31:10Z" webUrl="4"/>
+  <Project name="success-sleeping-project" activity="Sleeping" lastBuildStatus="Success" lastBuildTime="2015-12-09T10:31:10Z" lastBuildLabel="648" webUrl="1"/>
+  <Project name="success-building-project" activity="Building" lastBuildStatus="Success" lastBuildTime="2015-12-09T10:31:10Z" lastBuildLabel="1090" webUrl="2"/>
+  <Project name="failure_sleeping_project" activity="Sleeping" lastBuildStatus="Failure" lastBuildTime="2015-12-09T10:31:10Z" lastBuildLabel="220" webUrl="3"/>
+  <Project name="failure_building_project" activity="Building" lastBuildStatus="Failure" lastBuildTime="2015-12-09T10:31:10Z" lastBuildLabel="919" webUrl="4"/>
   <random stuff="random-stuff"/>
 </Projects>

--- a/src/client/actions/SettingsActions.js
+++ b/src/client/actions/SettingsActions.js
@@ -27,3 +27,8 @@ export function setRefreshTime(value) {
     value: intValue >= MIN_REFRESH_TIME ? intValue : MIN_REFRESH_TIME
   }
 }
+
+export const SHOW_BUILD_LABEL = 'SHOW_BUILD_LABEL'
+export function setShowBrokenBuildLabel(value) {
+	return {type: SHOW_BUILD_LABEL, value}
+}

--- a/src/client/common/project/InterestingProject.js
+++ b/src/client/common/project/InterestingProject.js
@@ -17,6 +17,7 @@ class InterestingProject extends Component {
 
     const timeBrokenLabel = _.isEmpty(_.trim(this.props.lastBuildTime)) ? '??' : moment(this.props.lastBuildTime).fromNow(true)
     const timeBroken = this.props.showBrokenBuildTimers && isSick ? <span className='time-broken'> {timeBrokenLabel}</span> : null
+    const buildLabel = this.props.showBrokenBuildLabel && !_.isEmpty(_.trim(this.props.lastBuildLabel)) ? <span className='build-label'> #{this.props.lastBuildLabel}</span> : null
 
     return (
       <div className={classes} data-locator='interesting-project'>
@@ -25,6 +26,7 @@ class InterestingProject extends Component {
           <span data-locator='project-name'>{this.props.name}</span>
           {stage}
           {timeBroken}
+          {buildLabel}
         </div>
       </div>
     )
@@ -37,8 +39,10 @@ InterestingProject.propTypes = {
   stage: PropTypes.string,
   trayName: PropTypes.string,
   lastBuildTime: PropTypes.string,
+  lastBuildLabel: PropTypes.string,
   showBrokenBuildTimers: PropTypes.bool,
-  showTrayName: PropTypes.bool
+  showTrayName: PropTypes.bool,
+  showBrokenBuildLabel: PropTypes.bool
 }
 
 export default InterestingProject

--- a/src/client/common/project/interesting-project.scss
+++ b/src/client/common/project/interesting-project.scss
@@ -37,4 +37,8 @@
     opacity: 0.5;
     font-style: italic;
   }
+
+  .build-label {
+    opacity: 0.5;
+  }
 }

--- a/src/client/common/repo/Data.js
+++ b/src/client/common/repo/Data.js
@@ -21,6 +21,7 @@ export const SCHEMA = {
       properties: {
         showTrayName: {type: 'boolean'},
         showBrokenBuildTime: {type: 'boolean'},
+        showBrokenBuildLabel: {type: 'boolean'},
         playBrokenBuildSoundFx: {type: 'boolean'},
         brokenBuildSoundFx: {type: ['string', 'null']},
         refreshTime: {type: 'number'}

--- a/src/client/monitor/InterestingProjects.js
+++ b/src/client/monitor/InterestingProjects.js
@@ -15,8 +15,7 @@ class InterestingProjects extends Component {
     const playBrokenSfx = this.props.playBrokenBuildSounds && this.props.projects.reduce((previous, project) => {
         return previous || project.prognosis === 'sick'
       }, false)
-    const brokenSfx = playBrokenSfx && this.props.brokenBuildFx ?
-      <audio ref={(node) => this.sfx = node} src={this.props.brokenBuildFx} autoPlay/> : null
+    const brokenSfx = playBrokenSfx && this.props.brokenBuildFx ? <audio ref={(node) => this.sfx = node} src={this.props.brokenBuildFx} autoPlay/> : null
 
     return (
       <span className='interesting-projects' data-locator='interesting-projects'>
@@ -24,9 +23,10 @@ class InterestingProjects extends Component {
           {
             this.props.projects.map((project) => {
               const tray = this.props.trays.find((tray) => tray.trayId === project.trayId)
-              return <InterestingProject {...project} trayName={tray.name} key={`${tray.trayId}#${project.projectId}`}
+              return <InterestingProject {...project} trayName={tray.name} key={project.projectId}
                                          showBrokenBuildTimers={this.props.showBrokenBuildTimers}
-                                         showTrayName={this.props.showTrayName}/>
+                                         showTrayName={this.props.showTrayName}
+                                         showBrokenBuildLabel={this.props.showBrokenBuildLabel}/>
             })
           }
         </ScaledGrid>
@@ -40,14 +40,12 @@ InterestingProjects.propTypes = {
   projects: PropTypes.arrayOf(PropTypes.shape({
     projectId: PropTypes.string.isRequired
   })).isRequired,
-  trays: PropTypes.arrayOf(PropTypes.shape({
-    trayId: PropTypes.string.isRequired,
-    name: PropTypes.string
-  })).isRequired,
+  trays: PropTypes.arrayOf(PropTypes.object).isRequired,
   showBrokenBuildTimers: PropTypes.bool,
   showTrayName: PropTypes.bool,
   playBrokenBuildSounds: PropTypes.bool,
-  brokenBuildFx: PropTypes.string
+  brokenBuildFx: PropTypes.string,
+  showBrokenBuildLabel: PropTypes.bool
 }
 
 export default InterestingProjects

--- a/src/client/monitor/Monitor.js
+++ b/src/client/monitor/Monitor.js
@@ -50,6 +50,7 @@ Monitor.propTypes = {
   projects: PropTypes.arrayOf(PropTypes.object).isRequired,
   showBrokenBuildTimers: PropTypes.bool,
   showTrayName: PropTypes.bool,
+  showBrokenBuildLabel: PropTypes.bool,
   playBrokenBuildSounds: PropTypes.bool,
   brokenBuildFx: PropTypes.string,
   messages: PropTypes.arrayOf(PropTypes.string).isRequired,

--- a/src/client/monitor/MonitorContainer.js
+++ b/src/client/monitor/MonitorContainer.js
@@ -24,6 +24,7 @@ function mapStateToProps(store) {
     selected: store.get('selected'),
     showBrokenBuildTimers: audioVisual.get('showBrokenBuildTime'),
     showTrayName: audioVisual.get('showTrayName'),
+    showBrokenBuildLabel: audioVisual.get('showBrokenBuildLabel'),
     playBrokenBuildSounds: audioVisual.get('playBrokenBuildSoundFx'),
     brokenBuildFx: audioVisual.get('brokenBuildSoundFx'),
     messages: store.get('success'),

--- a/src/client/reducers/SettingsReducer.js
+++ b/src/client/reducers/SettingsReducer.js
@@ -1,5 +1,5 @@
 import Immutable from 'immutable'
-import {BROKEN_BUILD_SOUND_FX, PLAY_BROKEN_BUILD_SOUND_FX, SHOW_BROKEN_BUILD_TIME, SHOW_TRAY_NAME, REFRESH_TIME} from '../actions/SettingsActions'
+import {BROKEN_BUILD_SOUND_FX, PLAY_BROKEN_BUILD_SOUND_FX, SHOW_BROKEN_BUILD_TIME, SHOW_TRAY_NAME, REFRESH_TIME, SHOW_BUILD_LABEL} from '../actions/SettingsActions'
 import {INITIALISED} from '../actions/NevergreenActions'
 import {IMPORT_SUCCESS} from '../actions/ImportActions'
 import defaultSoundFx from '../settings/pacman_death.mp3'
@@ -9,7 +9,8 @@ const DefaultState = Immutable.Map({
   showBrokenBuildTime: true,
   playBrokenBuildSoundFx: false,
   brokenBuildSoundFx: defaultSoundFx,
-  refreshTime: 5
+  refreshTime: 5,
+  showBrokenBuildLabel: true
 })
 
 export function reduce(state = DefaultState, action) {
@@ -32,6 +33,9 @@ export function reduce(state = DefaultState, action) {
 
     case REFRESH_TIME:
       return state.set('refreshTime', action.value)
+
+    case SHOW_BUILD_LABEL:
+      return state.set('showBrokenBuildLabel', action.value)
 
     default:
       return state

--- a/src/client/settings/DisplaySettings.js
+++ b/src/client/settings/DisplaySettings.js
@@ -11,12 +11,16 @@ import './display-settings.scss'
 class DisplaySettings extends Component {
   constructor(props) {
     super(props)
-    this.state = {lastBuildTime: moment.utc().toISOString()}
+    this.state = {
+      lastBuildTime: moment.utc().toISOString(),
+      lastBuildLabel: '1234'
+    }
   }
 
   render() {
     const toggleBrokenBuilds = (newValue) => this.props.setShowBrokenBuildTime(newValue)
     const toggleTrayName = (newValue) => this.props.setShowTrayName(newValue)
+    const toggleBuildLabel = (newValue) => this.props.setShowBrokenBuildLabel(newValue)
 
     return (
       <Container title='display' className='display'>
@@ -26,17 +30,40 @@ class DisplaySettings extends Component {
         <Checkbox checked={this.props.showBrokenBuildTime} onToggle={toggleBrokenBuilds} data-locator='show-times'>
           <span>show broken build time</span>
         </Checkbox>
+        <Checkbox checked={this.props.showBrokenBuildLabel} onToggle={toggleBuildLabel} data-locator='show-labels'>
+          <span>show broken build label</span>
+        </Checkbox>
         <h4 className='display-preview-title'>Preview</h4>
         <div className='display-preview'>
           <ScaledGrid>
-            <InterestingProject trayName={generateRandomName()} name='sick' prognosis='sick' lastBuildTime={this.state.lastBuildTime}
-                                showBrokenBuildTimers={this.props.showBrokenBuildTime} showTrayName={this.props.showTrayName}/>
-            <InterestingProject trayName={generateRandomName()} name='sick building' prognosis='sick-building'
-                                showBrokenBuildTimers={this.props.showBrokenBuildTime} showTrayName={this.props.showTrayName}/>
-            <InterestingProject trayName={generateRandomName()} name='healthy building' prognosis='healthy-building'
-                                showBrokenBuildTimers={this.props.showBrokenBuildTime} showTrayName={this.props.showTrayName}/>
-            <InterestingProject trayName={generateRandomName()} name='unknown' prognosis='unknown'
-                                showBrokenBuildTimers={this.props.showBrokenBuildTime} showTrayName={this.props.showTrayName}/>
+            <InterestingProject trayName={generateRandomName()}
+              name='sick' prognosis='sick'
+              lastBuildTime={this.state.lastBuildTime}
+              lastBuildLabel={this.state.lastBuildLabel}
+              showBrokenBuildTimers={this.props.showBrokenBuildTime}
+              showTrayName={this.props.showTrayName}
+              showBrokenBuildLabel={this.props.showBrokenBuildLabel}/>
+            <InterestingProject trayName={generateRandomName()}
+              name='sick building'
+              prognosis='sick-building'
+              lastBuildLabel={this.state.lastBuildLabel}
+              showBrokenBuildTimers={this.props.showBrokenBuildTime}
+              showTrayName={this.props.showTrayName}
+              showBrokenBuildLabel={this.props.showBrokenBuildLabel}/>
+            <InterestingProject trayName={generateRandomName()}
+              name='healthy building'
+              prognosis='healthy-building'
+              lastBuildLabel={this.state.lastBuildLabel}
+              showBrokenBuildTimers={this.props.showBrokenBuildTime}
+              showTrayName={this.props.showTrayName}
+              showBrokenBuildLabel={this.props.showBrokenBuildLabel}/>
+            <InterestingProject trayName={generateRandomName()}
+              name='unknown'
+              prognosis='unknown'
+              lastBuildLabel={this.state.lastBuildLabel}
+              showBrokenBuildTimers={this.props.showBrokenBuildTime}
+              showTrayName={this.props.showTrayName}
+              showBrokenBuildLabel={this.props.showBrokenBuildLabel}/>
           </ScaledGrid>
         </div>
       </Container>
@@ -47,8 +74,10 @@ class DisplaySettings extends Component {
 DisplaySettings.propTypes = {
   showTrayName: PropTypes.bool.isRequired,
   showBrokenBuildTime: PropTypes.bool.isRequired,
+  showBrokenBuildLabel: PropTypes.bool.isRequired,
   setShowBrokenBuildTime: PropTypes.func.isRequired,
-  setShowTrayName: PropTypes.func.isRequired
+  setShowTrayName: PropTypes.func.isRequired,
+  setShowBrokenBuildLabel: PropTypes.func.isRequired
 }
 
 export default DisplaySettings

--- a/src/client/settings/Settings.js
+++ b/src/client/settings/Settings.js
@@ -21,13 +21,15 @@ Settings.propTypes = {
   showTrayName: PropTypes.bool.isRequired,
   showBrokenBuildTime: PropTypes.bool.isRequired,
   playBrokenBuildSoundFx: PropTypes.bool.isRequired,
+  showBrokenBuildLabel: PropTypes.bool.isRequired,
   brokenBuildSoundFx: PropTypes.string,
   setShowBrokenBuildTime: PropTypes.func.isRequired,
   setShowTrayName: PropTypes.func.isRequired,
   setPlayBrokenBuildSoundFx: PropTypes.func.isRequired,
   setBrokenBuildSoundFx: PropTypes.func.isRequired,
   refreshTime: PropTypes.number.isRequired,
-  setRefreshTime: PropTypes.func.isRequired
+  setRefreshTime: PropTypes.func.isRequired,
+  setShowBrokenBuildLabel: PropTypes.func.isRequired
 }
 
 export default Settings

--- a/src/client/settings/SettingsContainer.js
+++ b/src/client/settings/SettingsContainer.js
@@ -1,6 +1,6 @@
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
-import {setBrokenBuildSoundFx, setPlayBrokenBuildSoundFx, setRefreshTime, setShowBrokenBuildTime, setShowTrayName} from '../actions/SettingsActions'
+import {setBrokenBuildSoundFx, setPlayBrokenBuildSoundFx, setRefreshTime, setShowBrokenBuildTime, setShowTrayName, setShowBrokenBuildLabel} from '../actions/SettingsActions'
 import Settings from './Settings'
 
 function mapDispatchToProps(dispatch) {
@@ -9,7 +9,8 @@ function mapDispatchToProps(dispatch) {
     setPlayBrokenBuildSoundFx,
     setBrokenBuildSoundFx,
     setShowTrayName,
-    setRefreshTime
+    setRefreshTime,
+    setShowBrokenBuildLabel
   }, dispatch)
 }
 

--- a/test/client/actions/SettingsActionsTest.js
+++ b/test/client/actions/SettingsActionsTest.js
@@ -7,11 +7,13 @@ import {
   setPlayBrokenBuildSoundFx,
   setBrokenBuildSoundFx,
   setRefreshTime,
+  setShowBrokenBuildLabel,
   SHOW_BROKEN_BUILD_TIME,
   SHOW_TRAY_NAME,
   PLAY_BROKEN_BUILD_SOUND_FX,
   BROKEN_BUILD_SOUND_FX,
-  REFRESH_TIME
+  REFRESH_TIME,
+  SHOW_BUILD_LABEL
 } from '../../../src/client/actions/SettingsActions'
 
 describe('SettingsActions', function () {
@@ -87,6 +89,18 @@ describe('SettingsActions', function () {
         const actual = setRefreshTime(value)
         expect(actual).to.have.property('value', 5)
       })
+    })
+  })
+
+  describe('setting broken build label', function() {
+    it('should return the correct type', function () {
+      const actual = setShowBrokenBuildLabel()
+      expect(actual).to.have.property('type', SHOW_BUILD_LABEL)
+    })
+
+    it('should return the given value', function () {
+      const actual = setShowTrayName(true)
+      expect(actual).to.have.property('value', true)
     })
   })
 })

--- a/test/client/common/project/InterestingProjectTest.js
+++ b/test/client/common/project/InterestingProjectTest.js
@@ -94,4 +94,19 @@ describe('<InterestingProject/>', function () {
       expect(wrapper.find('.time-broken')).to.have.text().match(/^ [ 0-9a-zA-Z]*$/)
     })
   })
+
+  describe('broken build label', function () {
+    it('should not be shown if disabled', function () {
+      const props = Object.assign({}, DEFAULT_PROPS, {showBrokenBuildLabel: false})
+      const wrapper = shallow(<InterestingProject {...props} />)
+      expect(wrapper.find('.build-label')).to.not.be.present()
+    })
+
+    it('should be shown if enabled and not empty', function() {
+      const props = Object.assign({}, DEFAULT_PROPS, {showBrokenBuildLabel: true, lastBuildLabel: '1234'})
+      const wrapper = shallow(<InterestingProject {...props} />)
+      expect(wrapper.find('.build-label')).to.be.present()
+      expect(wrapper.find('.build-label').text()).to.equal(' #1234')
+    })
+  })
 })

--- a/test/client/reducers/SettingsReducerTest.js
+++ b/test/client/reducers/SettingsReducerTest.js
@@ -57,6 +57,13 @@ describe('SettingsReducer', function () {
       const newState = reduce(existingState, action)
       expect(newState).to.contain.property('refreshTime', 10)
     })
+
+    it('should merge show build label', function () {
+      const existingState = Immutable.Map({showBrokenBuildLabel: false})
+      const action = {type: INITIALISED, data: Immutable.fromJS({audioVisual: {showBrokenBuildLabel: true}})}
+      const newState = reduce(existingState, action)
+      expect(newState).to.contain.property('showBrokenBuildLabel', true)
+    })
   })
 
   describe('imported data action', function () {
@@ -87,6 +94,13 @@ describe('SettingsReducer', function () {
       const action = {type: IMPORT_SUCCESS, data: Immutable.fromJS({audioVisual: {brokenBuildSoundFx: 'another-url'}})}
       const newState = reduce(existingState, action)
       expect(newState).to.contain.property('brokenBuildSoundFx', 'another-url')
+    })
+
+    it('should merge show build label', function () {
+      const existingState = Immutable.Map({showBrokenBuildLabel: false})
+      const action = {type: IMPORT_SUCCESS, data: Immutable.fromJS({audioVisual: {showBrokenBuildLabel: true}})}
+      const newState = reduce(existingState, action)
+      expect(newState).to.contain.property('showBrokenBuildLabel', true)
     })
   })
 

--- a/test/functional/functional_test.clj
+++ b/test/functional/functional_test.clj
@@ -81,7 +81,8 @@
     (doseq [state [true false]]
       (do (settings-page/show-names state)
           (settings-page/show-times state)
-          (settings-page/play-sounds state)))
+          (settings-page/play-sounds state)
+          (settings-page/show-labels state)))
 
     (backup-page/navigate base-url)
     (-> (backup-page/export-data)

--- a/test/functional/settings_page.clj
+++ b/test/functional/settings_page.clj
@@ -17,5 +17,11 @@
 (defn show-times [show]
   (checkbox show (locator "show-times")))
 
+(defn show-times [show]
+  (checkbox show (locator "show-times")))
+
 (defn play-sounds [play]
   (checkbox play (locator "play-sounds")))
+
+(defn show-labels [play]
+  (checkbox play (locator "show-labels")))


### PR DESCRIPTION
Hi. This PR is to show the label of broken builds on the monitor page.

Additionally following things are taken care of:
1. Option to enable/disable _show build label_ setting
2. Backup the _show build label_ setting

<img width="1422" alt="screen shot 2017-07-22 at 10 44 25 pm" src="https://user-images.githubusercontent.com/6568319/28493179-895acd8a-6f2f-11e7-957a-2b608a4c0805.png">

Cheers,
arunvelsriram