### PR TITLE
Shorten the build label

### DIFF
--- a/ci_stub_server/cctray.xml
+++ b/ci_stub_server/cctray.xml
@@ -1,7 +1,7 @@
 <Projects>
   <Project name="success-sleeping-project" activity="Sleeping" lastBuildStatus="Success" lastBuildTime="2015-12-09T10:31:10Z" lastBuildLabel="648" webUrl="1"/>
   <Project name="success-building-project" activity="Building" lastBuildStatus="Success" lastBuildTime="2015-12-09T10:31:10Z" lastBuildLabel="1090" webUrl="2"/>
-  <Project name="failure_sleeping_project" activity="Sleeping" lastBuildStatus="Failure" lastBuildTime="2015-12-09T10:31:10Z" lastBuildLabel="220" webUrl="3"/>
+  <Project name="failure_sleeping_project" activity="Sleeping" lastBuildStatus="Failure" lastBuildTime="2015-12-09T10:31:10Z" lastBuildLabel="4729.016bdd45611fc709a88bc2b7bee99c969a8c1377" webUrl="3"/>
   <Project name="failure_building_project" activity="Building" lastBuildStatus="Failure" lastBuildTime="2015-12-09T10:31:10Z" lastBuildLabel="919" webUrl="4"/>
   <random stuff="random-stuff"/>
 </Projects>

--- a/src/client/common/project/InterestingProject.js
+++ b/src/client/common/project/InterestingProject.js
@@ -18,7 +18,7 @@ class InterestingProject extends Component {
     const timeBrokenLabel = _.isEmpty(_.trim(this.props.lastBuildTime)) ? '??' : moment(this.props.lastBuildTime).fromNow(true)
     const timeBroken = this.props.showBrokenBuildTimers && isSick ? <span className='time-broken'> {timeBrokenLabel}</span> : null
     const buildLabel = this.props.showBuildLabel && isSick && !_.isEmpty(_.trim(this.props.lastBuildLabel)) ?
-      <span className='build-label'> #{this.props.lastBuildLabel}</span> : null
+      <span className='build-label'> #{this.props.lastBuildLabel.substr(0, 10)}</span> : null
 
     return (
       <div className={classes} data-locator='interesting-project'>

--- a/test/client/common/project/InterestingProjectTest.js
+++ b/test/client/common/project/InterestingProjectTest.js
@@ -120,5 +120,11 @@ describe('<InterestingProject/>', function () {
       expect(wrapper.find('.build-label')).to.be.present()
       expect(wrapper.find('.build-label').text()).to.equal(' #1234')
     })
+
+      it('should trim the build label to 10 characters', function () {
+      const props = Object.assign({}, DEFAULT_PROPS, {showBuildLabel: true, lastBuildLabel: '12345678901234567890', prognosis: 'sick'})
+      const wrapper = shallow(<InterestingProject {...props} />)
+      expect(wrapper.find('.build-label').text()).to.equal(' #1234567890')
+    })
   })
 })


### PR DESCRIPTION
When build label is lengthy (like this 4729.016bdd45611fc709a88bc2b7bee99c969a8c1377), font become too small making the UI look bad.

**Lengthy build label:**

<img width="1439" alt="screen shot 2017-09-11 at 6 31 07 pm" src="https://user-images.githubusercontent.com/6568319/30275606-8d5bd236-971f-11e7-8ed1-32ea3025006c.png">

This PR fixes the issue by trimming the build label to 10 characters length.

**After trimming:**

<img width="1440" alt="screen shot 2017-09-11 at 6 34 27 pm" src="https://user-images.githubusercontent.com/6568319/30275703-e1e1b3c0-971f-11e7-998f-0d8ba9651298.png">

Thanks,
Arun

