### PR TITLE
#239 Allow iframes to be used if specifically allowed by the server admin

### DIFF
--- a/src/nevergreen/config.clj
+++ b/src/nevergreen/config.clj
@@ -6,6 +6,8 @@
 (def ^:private aes-key-length 16)
 (def default-aes-key "abcdefghijklmnop")
 (def default-ip "0.0.0.0")
+(def default-port 5000)
+(def default-csp-frame-ancestors "'self'")
 
 (def ^:private use-default-key
   (delay
@@ -15,12 +17,6 @@
 (defn- invalid-key [aes-key]
   (throw (IllegalArgumentException. (str "An invalid AES_KEY was provided with length [" (count aes-key) "], a key length of [" aes-key-length "] is required"))))
 
-(defn port []
-  (Integer. (or (env :port) 5000)))
-
-(defn ip []
-  (or (env :ip) default-ip))
-
 (defn aes-key []
   (let [aes-key (env :aes-key)]
     (cond
@@ -28,5 +24,14 @@
       (= aes-key-length (count aes-key)) aes-key
       :else (invalid-key aes-key))))
 
+(defn port []
+  (Integer. (or (env :port) default-port)))
+
+(defn ip []
+  (or (env :ip) default-ip))
+
 (defn log-level []
   (keyword (env :log-level)))
+
+(defn allow-iframe-from []
+  (or (env :allow-iframe-from) default-csp-frame-ancestors))

--- a/src/nevergreen/wrap_content_security_policy.clj
+++ b/src/nevergreen/wrap_content_security_policy.clj
@@ -1,21 +1,23 @@
 (ns nevergreen.wrap-content-security-policy
   (:require [clojure.string :refer [starts-with? join]]
+            [nevergreen.config :as config]
             [ring.util.response :refer [get-header]]))
 
-(def ^:private default-src "default-src 'self'")
-(def ^:private script-src "script-src 'self' 'unsafe-eval'")
-(def ^:private worker-src "worker-src 'self'")
-(def ^:private style-src "style-src 'self' 'unsafe-inline'")
-(def ^:private img-src "img-src * data:")
-(def ^:private font-src "font-src 'self' data:")
-(def ^:private media-src "media-src *")
-(def ^:private connect-src "connect-src 'self' https://api.github.com https://gist.githubusercontent.com")
-(def ^:private object-src "object-src 'none'")
-(def ^:private child-src "child-src 'self'")
-(def ^:private frame-src "frame-src 'none'")
-(def ^:private sources [default-src script-src worker-src style-src img-src font-src media-src connect-src object-src child-src frame-src])
+(defn- csp-headers []
+  ["default-src 'self'"
+   "script-src 'self' 'unsafe-eval'"
+   "worker-src 'self'"
+   "style-src 'self' 'unsafe-inline'"
+   "img-src * data:"
+   "font-src 'self' data:"
+   "media-src *"
+   "connect-src 'self' https://api.github.com https://gist.githubusercontent.com"
+   "object-src 'none'"
+   (str "frame-ancestors " (config/allow-iframe-from))])
 
 (defn wrap-content-security-policy [app]
   (fn [req]
     (let [res (app req)]
-      (assoc-in res [:headers "Content-Security-Policy"] (join "; " sources)))))
+      (-> res
+          (assoc-in [:headers "X-Frame-Options"] nil)
+          (assoc-in [:headers "Content-Security-Policy"] (join "; " (csp-headers)))))))

--- a/test/nevergreen/config_test.clj
+++ b/test/nevergreen/config_test.clj
@@ -12,7 +12,16 @@
        (fact "defaults to 5000"
              (subject/port) => 5000
              (provided
-                (env :port) => nil)))
+               (env :port) => nil)))
+
+(fact "allow-iframe-from"
+      (fact "defaults to 5000"
+            (subject/allow-iframe-from) => "host:port"
+            (provided
+              (env :allow-iframe-from) => "host:port"))
+
+      (fact "use default if not set in env"
+            (subject/allow-iframe-from) => "'self'"))
 
 (facts "aes encryption key"
        (fact "from env"


### PR DESCRIPTION
Fixes issue #239

This creates a new environment variable called `ALLOW_IFRAME_FROM` which gets put into the HTTP Headers as:

`Content-Security-Policy: ...........; frame-ancestors 192.168.100.115:8000`

Which otherwise defaults to 'self' which is the same as SAMEORIGIN in X-FRAME-OPTIONS parlance.

You use it by:

`ALLOW_IFRAME_FROM=192.168.100.115:8000 java -jar nevergreen.jar`

If accepted we'll beed to update the wiki/docs to let folk know about this option