### PR TITLE
[#305] updates pre-push script to immediately kill all child processes

### DIFF
--- a/pre-push.sh
+++ b/pre-push.sh
@@ -26,7 +26,7 @@ print_step 'Checking prerequisites'
 
 print_step 'Stopping the ./develop.sh script (if it is running)'
 set +e
-pkill -SIGINT -f ./develop.sh
+kill -9 -- -$(pgrep -f develop.sh)
 set -e
 
 print_step 'Validating CI configuration (if the CircleCI CLI is installed)'


### PR DESCRIPTION
Fixes issue #305

I think the reason this was failing originally is because child processes such as node weren't being _immediately_ killed. This is a bit of a nuclear option admittedly, but I'm pretty sure `pgrep` is a standard linux tool these days?

@build-canaries/owners
